### PR TITLE
Add Worksheet#rows monkeypatch

### DIFF
--- a/lib/aspire_budget.rb
+++ b/lib/aspire_budget.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'core_extensions'
+
 require 'configuration'
 
 require 'worksheets/backend_data'

--- a/lib/core_extensions.rb
+++ b/lib/core_extensions.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+require 'google_drive'
+
+module AspireBudget
+  module CoreExtensions
+    module Worksheet
+      def rows(skip = 0, cell_method: :[])
+        nc = num_cols
+        result = ((1 + skip)..num_rows).map do |row|
+          (1..nc).map { |col| send(cell_method, row, col) }.freeze
+        end
+        result.freeze
+      end
+    end
+  end
+end
+
+# https://github.com/gimite/google-drive-ruby/issues/378
+GoogleDrive::Worksheet.prepend AspireBudget::CoreExtensions::Worksheet


### PR DESCRIPTION
The monkeypatch intention is to use #rows for numeric_values. This will allow us to:

- drop need to use Money gem
- be locale agnostic

The monkeypatch is a temporary solution until we have an update on https://github.com/gimite/google-drive-ruby/issues/378